### PR TITLE
[READY] mr/elb func : Added ELB that routes to worker asg and added helm/k8s config

### DIFF
--- a/terraform/elb.tf
+++ b/terraform/elb.tf
@@ -48,15 +48,16 @@ resource "aws_autoscaling_attachment" "drone" {
   autoscaling_group_name = "${module.eks.workers_asg_names[0]}"
   elb                    = "${aws_elb.drone.id}"
 }
+
 output "crontupisto" {
   value = "${module.eks.cluster_security_group_id}"
 }
 
 resource "aws_security_group_rule" "allow_lb" {
-  type = "ingress"
-  from_port = 30080
-  to_port = 30080
-  protocol = "tcp"
+  type                     = "ingress"
+  from_port                = 30080
+  to_port                  = 30080
+  protocol                 = "tcp"
   source_security_group_id = "${aws_security_group.drone_elb.id}"
 
   security_group_id = "${module.eks.worker_security_group_id}"

--- a/terraform/helm/values.yaml
+++ b/terraform/helm/values.yaml
@@ -1,0 +1,16 @@
+service:
+  # Leave this port service definition alone. The load balancer being created via the terraform aws provider
+  # is load balancing to this port on the kubernetes worker asg.
+  type: NodePort
+  nodePort: 30080
+  targetPort: 80
+server:
+  # This is the url that you'd like to reach drone at. It must match the url provided to the github oauth app
+  host: "http://drone-url"
+  env:
+    DRONE_PROVIDER: "github"
+    DRONE_OPEN: "false"
+    DRONE_GITHUB: "true"
+    DRONE_ADMIN: "github_username"
+    DRONE_GITHUB_CLIENT: "github oauth app client id"
+    DRONE_GITHUB_SECRET: "github oauth app secret"

--- a/terraform/k8s/rbac-config.yaml
+++ b/terraform/k8s/rbac-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = "=0.11.11"
+
+  backend "s3" {
+    bucket = "<bucket_name>"
+    key    = "terraform.tfstate"
+    region = "us-west-2"
+  }
 }
 
 provider "aws" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "kube_config" {
-  value = "${module.eks.kubeconfig}"
+output "elb_host_name" {
+  value = "${aws_elb.drone.dns_name}"
 }


### PR DESCRIPTION
## Description of PR
* Added an elb that load balances to NodePort Service running in eks. This NodePort service routes to drone.
* Added kube yaml file that defines a service account and cluster role binding for tiller.
* Added drone helm chart values.yaml file. 

## Previous Behavior
There was no elb, tiller-related k8s object defined, or a drone values.yaml file.

## New Behavior
Added all of the above.

## Tests
`terraform plan` and `terraform apply` run in dev env